### PR TITLE
Error when trying to create sendgrid instance

### DIFF
--- a/sendgrid.ts
+++ b/sendgrid.ts
@@ -20,7 +20,7 @@ expression whose type lacks a call signature. (2349)".
 */
 
 // Uncomment this line to cause the error.
-// import * as Sendgrid from 'sendgrid';
+// import * as SendGrid from 'sendgrid';
 
 
 

--- a/sendgrid.ts
+++ b/sendgrid.ts
@@ -1,5 +1,30 @@
-import {SendGrid} from "sendgrid";
+declare const require: any; // To quench error
 
+
+// The following line imports sendgrid correctly
+import { SendGrid } from "sendgrid";
+console.log(SendGrid); // undefined
+
+
+// The following line import sendgrid correctly (uncomment to test it out)
+// const SendGrid = require('sendgrid');
+// console.log(SendGrid); // an object
+
+/*
+The import statement line below is the same as the require statement above.
+This is the correct way to use the sendgrid api, as using `import { Sendgrid } from 'sendgrid'` will result in Sendgrid
+being undefined. (as shown above).
+
+Although the wildcard import works, actually calling the imported function results in the error "Cannot invoke an
+expression whose type lacks a call signature. (2349)".
+*/
+
+// Uncomment this line to cause the error.
+// import * as Sendgrid from 'sendgrid';
+
+
+
+// When using wildcard import, this causes the error "Cannot invoke an expression whose type lacks a call signature."
 const sendGrid = SendGrid("");
 
 export default sendGrid;

--- a/sendgrid.ts
+++ b/sendgrid.ts
@@ -26,5 +26,6 @@ expression whose type lacks a call signature. (2349)".
 
 // When using wildcard import, this causes the error "Cannot invoke an expression whose type lacks a call signature."
 const sendGrid = SendGrid("");
+console.log(sendGrid); // When using the require or wildcard import, this is a SendGridInstance
 
 export default sendGrid;


### PR DESCRIPTION
Hey there again!

After casting my `sendgrid` instance to `any` to work around #1, I was getting the classic "undefined is not a function" when trying to create an instance of SendGrid! 😱  It turned out that `import { SendGrid } from "sendgrid"` was returning `undefined`!

I worked out that in the docs, the code to create a `SendGrid` instance is: `const sendGrid = require('sengrid')(API_KEY);`. The equivalent code in TypeScript is 

``` ts
import * as Sendgrid from 'sendgrid';
const sendGrid = SendGrid("");
```

Unfortunately, this is causing the error `"Cannot invoke an
expression whose type lacks a call signature. (2349)".` when building with typescript, even though the emitted code works.

This PR is a repro of this issue. I'm using `ts-node sendgrid.ts` to run it, but `tsc && node sendgrid.js` will work the same (after removing `noEmit` from `tsconfig.json`) if you don't have `ts-node` installed. 

Thank you for looking at these issues! 
